### PR TITLE
made some sklearn utils

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -33,4 +33,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest
       run: |
-        unittest
+        python -m unittest tests/test_lr.py tests/test_calibration.py
+

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,7 +31,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with unittest
       run: |
-        pip install pytest
-        pytest
+        unittest

--- a/lir/sk_utils.py
+++ b/lir/sk_utils.py
@@ -1,0 +1,33 @@
+from sklearn.pipeline import Pipeline
+
+from lir import CalibratedScorer, CalibratedScorerCV
+
+
+class CalibratedScorerSk(CalibratedScorer):
+    """
+    As sklearn expects a `predict` in its estimator this class adds the `predict_lr` from the `CalibratedScorer`
+    also as `predict`.
+    In this way the `CalibratedScorer`, can be easily used in sklearn based pipelnes
+    """
+    def predict(self, X):
+        return super().predict_lr(X)
+
+
+class CalibratedScorerCVSk(CalibratedScorerCV):
+    """
+    As sklearn expects a `predict` in its estimator this class adds the `predict_lr` from the `CalibratedScorerCV`
+    also as `predict`.
+    In this way the `CalibratedScorerCV`, can be easily used in sklearn based pipelnes
+    """
+    def predict(self, X):
+        return super().predict_lr(X)
+
+
+class LirPipeline(Pipeline):
+    """
+    As lir can expects a `predict_lr` in its estimator this class adds the `predict` from the `Pipeline`
+    also as `predict_lr`.
+    In this way the `Pipeline` from sklearn, can be easily used in an lir based pipelnes
+    """
+    def predict_lr(self, X):
+        return super().predict(self, X)

--- a/lir/sk_utils.py
+++ b/lir/sk_utils.py
@@ -25,3 +25,37 @@ class LirPipeline(Pipeline):
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt)
         return self.steps[-1][-1].predict_lr(Xt)
+
+    def _validate_steps(self):
+        names, estimators = zip(*self.steps)
+
+        # validate names
+        self._validate_names(names)
+
+        # validate estimators
+        transformers = estimators[:-1]
+        estimator = estimators[-1]
+
+        for t in transformers:
+            if t is None or t == 'passthrough':
+                continue
+            if (not (hasattr(t, "fit") or hasattr(t, "fit_transform")) or not
+                    hasattr(t, "transform")):
+                raise TypeError("All intermediate steps should be "
+                                "transformers and implement fit and transform "
+                                "or be the string 'passthrough' "
+                                "'%s' (type %s) doesn't" % (t, type(t)))
+
+        # We allow last estimator to be None as an identity transformation
+        if (estimator is not None and estimator != 'passthrough'
+                and not hasattr(estimator, "fit")):
+            raise TypeError(
+                "Last step of Pipeline should implement fit "
+                "or be the string 'passthrough'. "
+                "'%s' (type %s) doesn't" % (estimator, type(estimator)))
+
+        if (type(estimator) is not CalibratedScorer):
+            raise TypeError(
+                "LirPipeline should only be used with CalibratedScorer."
+                "Used the default Pipeline instead"
+            )

--- a/lir/sk_utils.py
+++ b/lir/sk_utils.py
@@ -3,31 +3,25 @@ from sklearn.pipeline import Pipeline
 from lir import CalibratedScorer, CalibratedScorerCV
 
 
-class CalibratedScorerSk(CalibratedScorer):
-    """
-    As sklearn expects a `predict` in its estimator this class adds the `predict_lr` from the `CalibratedScorer`
-    also as `predict`.
-    In this way the `CalibratedScorer`, can be easily used in sklearn based pipelnes
-    """
-    def predict(self, X):
-        return super().predict_lr(X)
-
-
-class CalibratedScorerCVSk(CalibratedScorerCV):
-    """
-    As sklearn expects a `predict` in its estimator this class adds the `predict_lr` from the `CalibratedScorerCV`
-    also as `predict`.
-    In this way the `CalibratedScorerCV`, can be easily used in sklearn based pipelnes
-    """
-    def predict(self, X):
-        return super().predict_lr(X)
-
-
 class LirPipeline(Pipeline):
     """
     As lir can expects a `predict_lr` in its estimator this class adds the `predict` from the `Pipeline`
     also as `predict_lr`.
     In this way the `Pipeline` from sklearn, can be easily used in an lir based pipelnes
+
+    Parameters
+    ----------
+    X : iterable
+        Data to predict on. Must fulfill input requirements of first step
+        of the pipeline.
+
+    Returns
+    -------
+    y_pred : array-like
+        Likelihood-ratios for the data in X.
     """
     def predict_lr(self, X):
-        return super().predict(self, X)
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt)
+        return self.steps[-1][-1].predict_lr(Xt)


### PR DESCRIPTION
To smooth the process between sklearn and lir, I made some simple utils functions that map the `predict` to the `predict_lr` and vice-versa. I think of using the same name for convenience (e.g. the difference is purely based on the submodule, but maybe that is a bit to risky).