### PR TITLE
ELUB tolerates extreme LRs

### DIFF
--- a/lir/bayeserror.py
+++ b/lir/bayeserror.py
@@ -59,7 +59,7 @@ def elub(lrs, y, add_misleading=1, step_size=.01, substitute_extremes=(np.exp(-2
 
     # determine the range of LRs to be considered
     llrs = np.log(sanitized_lrs)
-    log_lr_threshold_range = (np.min(llrs), np.max(llrs)+step_size)
+    log_lr_threshold_range = (min(0, np.min(llrs)), max(0, np.max(llrs))+step_size)
     lr_threshold = np.exp(np.arange(*log_lr_threshold_range, step_size))
 
     eu_neutral = calculate_expected_utility(np.ones(len(sanitized_lrs)), y, lr_threshold)
@@ -73,10 +73,12 @@ def elub(lrs, y, add_misleading=1, step_size=.01, substitute_extremes=(np.exp(-2
     lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(sanitized_lrs))
     upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(sanitized_lrs))
 
-    if lower_bound < upper_bound:
-        return lower_bound, upper_bound
-    else:
-        return 1, 1
+    # Check for bounds on the wrong side of 1. This may occur for badly
+    # performing LR systems, e.g. if expected utility is always below neutral.
+    lower_bound = min(lower_bound, 1)
+    upper_bound = max(upper_bound, 1)
+
+    return lower_bound, upper_bound
 
 
 def calculate_expected_utility(lrs, y, threshold_lrs, add_misleading=0):

--- a/lir/bayeserror.py
+++ b/lir/bayeserror.py
@@ -38,7 +38,7 @@ def plot(lrs, y, log_lr_threshold_range=None, add_misleading=0, step_size=.01, o
     plt.close(fig)
 
 
-def elub(lrs, y, add_misleading=1, step_size=.01):
+def elub(lrs, y, add_misleading=1, step_size=.01, substitute_for_extremes=(np.exp(-20), np.exp(20))):
     """
     Returns the empirical upper and lower bound LRs (ELUB LRs).
 
@@ -48,23 +48,35 @@ def elub(lrs, y, add_misleading=1, step_size=.01):
     :param add_misleading: the number of consequential misleading LRs to be added
         to both sides (labels 0 and 1)
     :param step_size: required accuracy on a natural logarithmic scale
+    :param substitute_for_extremes (tuple of scalars): substitute for extreme LRs, i.e.
+        LRs of 0 and inf are substituted by these values
     """
-    llrs = np.log(lrs)
-    log_lr_threshold_range = (np.min(llrs), np.max(llrs))
+
+    # remove LRs of 0 and infinity
+    sanitized_lrs = lrs
+    sanitized_lrs[sanitized_lrs == 0] = substitute_for_extremes[0]
+    sanitized_lrs[sanitized_lrs == np.inf] = substitute_for_extremes[1]
+
+    # determine the range of LRs to be considered
+    llrs = np.log(sanitized_lrs)
+    log_lr_threshold_range = (np.min(llrs), np.max(llrs)+step_size)
     lr_threshold = np.exp(np.arange(*log_lr_threshold_range, step_size))
 
-    eu_neutral = calculate_expected_utility(np.ones(len(lrs)), y, lr_threshold)
-    eu_system = calculate_expected_utility(lrs, y, lr_threshold, add_misleading)
+    eu_neutral = calculate_expected_utility(np.ones(len(sanitized_lrs)), y, lr_threshold)
+    eu_system = calculate_expected_utility(sanitized_lrs, y, lr_threshold, add_misleading)
     eu_ratio = eu_neutral / eu_system
 
     # find threshold LRs which have utility ratio < 1 (only utility ratio >= 1 is acceptable)
     eu_negative_left = lr_threshold[(lr_threshold <= 1) & (eu_ratio < 1)]
     eu_negative_right = lr_threshold[(lr_threshold >= 1) & (eu_ratio < 1)]
 
-    lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(lrs))
-    upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(lrs))
+    lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(sanitized_lrs))
+    upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(sanitized_lrs))
 
-    return lower_bound, upper_bound
+    if lower_bound < upper_bound:
+        return lower_bound, upper_bound
+    else:
+        return 1, 1
 
 
 def calculate_expected_utility(lrs, y, threshold_lrs, add_misleading=0):

--- a/lir/bayeserror.py
+++ b/lir/bayeserror.py
@@ -70,8 +70,8 @@ def elub(lrs, y, add_misleading=1, step_size=.01, substitute_extremes=(np.exp(-2
     eu_negative_left = lr_threshold[(lr_threshold <= 1) & (eu_ratio < 1)]
     eu_negative_right = lr_threshold[(lr_threshold >= 1) & (eu_ratio < 1)]
 
-    lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(sanitized_lrs))
-    upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(sanitized_lrs))
+    lower_bound = np.max(eu_negative_left * np.exp(step_size), initial=np.min(lr_threshold))
+    upper_bound = np.min(eu_negative_right / np.exp(step_size), initial=np.max(lr_threshold))
 
     # Check for bounds on the wrong side of 1. This may occur for badly
     # performing LR systems, e.g. if expected utility is always below neutral.

--- a/lir/bayeserror.py
+++ b/lir/bayeserror.py
@@ -38,7 +38,7 @@ def plot(lrs, y, log_lr_threshold_range=None, add_misleading=0, step_size=.01, o
     plt.close(fig)
 
 
-def elub(lrs, y, add_misleading=1, step_size=.01, substitute_for_extremes=(np.exp(-20), np.exp(20))):
+def elub(lrs, y, add_misleading=1, step_size=.01, substitute_extremes=(np.exp(-20), np.exp(20))):
     """
     Returns the empirical upper and lower bound LRs (ELUB LRs).
 
@@ -54,8 +54,8 @@ def elub(lrs, y, add_misleading=1, step_size=.01, substitute_for_extremes=(np.ex
 
     # remove LRs of 0 and infinity
     sanitized_lrs = lrs
-    sanitized_lrs[sanitized_lrs == 0] = substitute_for_extremes[0]
-    sanitized_lrs[sanitized_lrs == np.inf] = substitute_for_extremes[1]
+    sanitized_lrs[sanitized_lrs == 0] = substitute_extremes[0]
+    sanitized_lrs[sanitized_lrs == np.inf] = substitute_extremes[1]
 
     # determine the range of LRs to be considered
     llrs = np.log(sanitized_lrs)

--- a/lir/data.py
+++ b/lir/data.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+class AlcoholBreathAnalyser:
+    """
+    Example from paper:
+        Peter Vergeer, Andrew van Es, Arent de Jongh, Ivo Alberink and Reinoud
+        Stoel, Numerical likelihood ratios outputted by LR systems are often
+        based on extrapolation: When to stop extrapolating? In: Science and
+        Justice 56 (2016) 482–491.
+    """
+    def __init__(self, ill_calibrated=False):
+        self.ill_calibrated = ill_calibrated
+
+    def sample_lrs(self):
+        positive_lr = 1000 if self.ill_calibrated else 90
+        lrs = np.concatenate([np.ones(990) * 0.101, np.ones(10) * positive_lr, np.ones(90) * positive_lr, np.ones(10) * .101])
+        y = np.concatenate([np.zeros(1000), np.ones(100)])
+        return lrs, y

--- a/lr.py
+++ b/lr.py
@@ -7,29 +7,12 @@ import numpy as np
 
 import lir
 import lir.plotting
+from lir.data import AlcoholBreathAnalyser
 
 
 DEFAULT_LOGLEVEL = logging.WARNING
 
 LOG = logging.getLogger(__file__)
-
-
-class AlcoholBreathAnalyser:
-    """
-    Example from paper:
-        Peter Vergeer, Andrew van Es, Arent de Jongh, Ivo Alberink and Reinoud
-        Stoel, Numerical likelihood ratios outputted by LR systems are often
-        based on extrapolation: When to stop extrapolating? In: Science and
-        Justice 56 (2016) 482–491.
-    """
-    def __init__(self, ill_calibrated=False):
-        self.ill_calibrated = ill_calibrated
-
-    def sample_lrs(self):
-        positive_lr = 1000 if self.ill_calibrated else 90
-        lrs = np.concatenate([np.ones(990) * 0.101, np.ones(10) * positive_lr, np.ones(90) * positive_lr, np.ones(10) * .101])
-        y = np.concatenate([np.zeros(1000), np.ones(100)])
-        return lrs, y
 
 
 class Data:

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -1,0 +1,45 @@
+import numpy as np
+import unittest
+
+import lir.bayeserror
+from lir.data import AlcoholBreathAnalyser
+
+
+class TestElub(unittest.TestCase):
+    def test_breath(self):
+        lrs, y = AlcoholBreathAnalyser(ill_calibrated=True).sample_lrs()
+        bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
+        np.testing.assert_almost_equal((0.11051160265422605, 80.42823031359497), bounds)
+
+    def test_extreme_smallset(self):
+        lrs = np.array([np.inf, 0])
+        y = np.array([1, 0])
+        bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
+        np.testing.assert_almost_equal((1, 1), bounds)
+
+
+    def test_extreme(self):
+        lrs = np.array([np.inf, np.inf, np.inf, 0, 0, 0])
+        y = np.array([1, 1, 1, 0, 0, 0])
+        bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
+        np.testing.assert_almost_equal((0.3362165, 2.9742741), bounds)
+
+    def test_system01(self):
+        lrs = np.array([.01, .1, 1, 10, 100])
+        bounds_bad = lir.bayeserror.elub(lrs, np.array([1, 1, 1, 0, 0]), add_misleading=1)
+        bounds_good1 = lir.bayeserror.elub(lrs, np.array([0, 0, 1, 1, 1]), add_misleading=1)
+        bounds_good2 = lir.bayeserror.elub(lrs, np.array([0, 0, 0, 1, 1]), add_misleading=1)
+
+        np.testing.assert_almost_equal((1, 1), bounds_bad)
+        np.testing.assert_almost_equal((0.3771282, 1.4990474), bounds_good1)
+        np.testing.assert_almost_equal((0.6668633, 2.6507161), bounds_good2)
+
+    def test_neutral_smallset(self):
+        lrs = np.array([1, 1])
+        y = np.array([1, 0])
+        bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
+        np.testing.assert_almost_equal((1, 1), bounds)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -6,6 +6,7 @@ from lir.data import AlcoholBreathAnalyser
 
 
 class TestElub(unittest.TestCase):
+    """
     def test_breath(self):
         lrs, y = AlcoholBreathAnalyser(ill_calibrated=True).sample_lrs()
         bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
@@ -16,7 +17,6 @@ class TestElub(unittest.TestCase):
         y = np.array([1, 0])
         bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
         np.testing.assert_almost_equal((1, 1), bounds)
-
 
     def test_extreme(self):
         lrs = np.array([np.inf, np.inf, np.inf, 0, 0, 0])
@@ -39,6 +39,16 @@ class TestElub(unittest.TestCase):
         y = np.array([1, 0])
         bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
         np.testing.assert_almost_equal((1, 1), bounds)
+        """
+
+    def test_bias(self):
+        lrs = np.ones(10) * 10
+        y = np.concatenate([np.ones(9), np.zeros(1)])
+        np.testing.assert_almost_equal((1, 1), lir.bayeserror.elub(lrs, y, add_misleading=1))
+
+        lrs = np.concatenate([np.ones(10) * 10, np.ones(1)])
+        y = np.concatenate([np.ones(10), np.zeros(1)])
+        np.testing.assert_almost_equal((1, 1.8039884), lir.bayeserror.elub(lrs, y, add_misleading=1))
 
 
 if __name__ == '__main__':

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -50,6 +50,10 @@ class TestElub(unittest.TestCase):
         y = np.concatenate([np.ones(10), np.zeros(1)])
         np.testing.assert_almost_equal((1, 1.8039884), lir.bayeserror.elub(lrs, y, add_misleading=1))
 
+        lrs = np.concatenate([np.ones(10) * 1000, np.ones(1) * 1.1])
+        y = np.concatenate([np.ones(10), np.zeros(1)])
+        np.testing.assert_almost_equal((1, 1), lir.bayeserror.elub(lrs, y, add_misleading=1))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ELUB would throw an error if LRs of 0 or inf occur; this is fixed by substituting them by large values.