### PR TITLE
Fix wrong dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
 numpy
 scipy
-sklearn
+scikit-learn
 tqdm


### PR DESCRIPTION
`sklearn` is the module name, not the package name.
See also: https://pypi.org/project/sklearn/