### PR TITLE
Bugfix for ELUBbounder when transform uses reshape

### DIFF
--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -354,7 +354,7 @@ class ELUBbounder(BaseEstimator, TransformerMixin):
         if not also_fit_calibrator:
             # check the model was fitted.
             try:
-                first_step_calibrator.transform(0.5)
+                first_step_calibrator.transform(np.array([0.5]))
             except NotFittedError:
                 print('calibrator should have been fit when setting also_fit_calibrator = False!')
 

--- a/tests/test_elub.py
+++ b/tests/test_elub.py
@@ -6,7 +6,7 @@ from lir.data import AlcoholBreathAnalyser
 
 
 class TestElub(unittest.TestCase):
-    """
+
     def test_breath(self):
         lrs, y = AlcoholBreathAnalyser(ill_calibrated=True).sample_lrs()
         bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
@@ -39,7 +39,7 @@ class TestElub(unittest.TestCase):
         y = np.array([1, 0])
         bounds = lir.bayeserror.elub(lrs, y, add_misleading=1)
         np.testing.assert_almost_equal((1, 1), bounds)
-        """
+
 
     def test_bias(self):
         lrs = np.ones(10) * 10


### PR DESCRIPTION
 Fixes float object has no attribute reshape in ELUBbounder when using logitcalibrator

![image](https://user-images.githubusercontent.com/37905386/113133458-f6f7ab80-921f-11eb-9984-b9ee94cd1a97.png)
