### PR TITLE
Adds context manager to plot_pav

### DIFF
--- a/lir/plotting.py
+++ b/lir/plotting.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import math
 import warnings
+from contextlib import contextmanager
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -336,7 +337,7 @@ def makeplot_accuracy(scorer, density_function, X0_train, X1_train, X0_calibrate
     if show or savefig is None:
         plt.show()
 
-
+@contextmanager
 def plot_pav(lrs, y, add_misleading=0, show_scatter=True, savefig=None, show=None, kw_figure={}):
     """
     Generates a plot of pre- versus post-calibrated LRs using Pool Adjacent
@@ -425,12 +426,15 @@ def plot_pav(lrs, y, add_misleading=0, show_scatter=True, savefig=None, show=Non
     plt.xlabel("pre-calibrated 10log(lr)")
     plt.ylabel("post-calibrated 10log(lr)")
 
-    if savefig is not None:
-        plt.savefig(savefig)
-    if show or savefig is None:
-        plt.show()
+    try:
+        yield plt
+    finally:
+        if savefig:
+            plt.savefig(savefig)
+        if show or savefig is None:
+            plt.show()
 
-    plt.close(fig)
+        plt.close(fig)
 
 
 def plot_log_lr_distributions_for_model(lr_system: CalibratedScorer, X, y, kind: str = 'histogram', savefig=None,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("readme.md") as f:
     long_description = f.read()
 setup(
     name="lir",
-    version="0.0.8",
+    version="0.0.9",
     description="scripts for calculating likelihood ratios",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Gives you the possibility to use plot_pav in a contextmanager. Possible use case:

```python
with plot_pav(lrs, labels, show_scatter=True) as pav_calibrated:
    pav_calibrated.xlabel("Calibrated 10log(lr)")
    pav_calibrated.ylabel("PAV transformed 10log(lr)")
```