### PR TITLE
customizable plotting

### DIFF
--- a/lir/plotting.py
+++ b/lir/plotting.py
@@ -472,8 +472,6 @@ def axes(call, ax=None, savefig=None, show=None):
             _ax.savefig(savefig)
         if show:
             _ax.show()
-        if show is None and savefig is None:
-            _ax.show()
 
         if fig is not None:
             _ax.close(fig)

--- a/lir/plotting.py
+++ b/lir/plotting.py
@@ -433,7 +433,7 @@ def pav(lrs, y, add_misleading=0, show_scatter=True):
 
 
 @contextmanager
-def axes(call, ax=None, savefig=None, show=None):
+def axes(call, savefig=None, show=None):
     """
     Creates a plot, given a plotting function. To be used within a context to
     modify plotting parameters
@@ -449,32 +449,23 @@ def axes(call, ax=None, savefig=None, show=None):
     ----------
     call : callable
         a callable to generate the plot
-    ax : a pyplot axes object
-        where the plot is generated
     savefig : path to image file, or `None`
         if not `None`, a PNG image is written to the path
     show : boolean or None
         the plot is presented on screen if this value is `True` or if both `savefig` and `show` are `None`
     """
-    if ax is not None:
-        fig = None
-        _ax = ax
-    else:
-        fig = plt.figure()
-        _ax = plt
-
-    call(ax=_ax)
+    fig = plt.figure()
+    call(ax=plt)
 
     try:
         yield plt
     finally:
         if savefig:
-            _ax.savefig(savefig)
+            plt.savefig(savefig)
         if show:
-            _ax.show()
+            plt.show()
 
-        if fig is not None:
-            _ax.close(fig)
+        plt.close(fig)
 
 
 def plot(call, ax=None, savefig=None, show=None):
@@ -494,12 +485,17 @@ def plot(call, ax=None, savefig=None, show=None):
     ax : a pyplot axes object
         where the plot is generated
     savefig : str
-        if not `None`, write a PNG image to this path
+        if not `None`, write a PNG image to this path (valid only if `ax` is None)
     show : boolean
-        if `True`, show the plot on screen
+        if `True`, show the plot on screen (valid only if `ax` is None)
     """
-    with axes(call, ax, savefig, show) as ax:
-        pass
+    if ax is None:
+        with axes(call, savefig, show) as ax:
+            pass
+    else:
+        assert savefig is None, "both `ax` and `savefig` are provided"
+        assert show is None, "both `ax` and `show` are provided"
+        call(ax=ax)
 
 
 def plot_log_lr_distributions_for_model(lr_system: CalibratedScorer, X, y, kind: str = 'histogram', savefig=None,

--- a/lir/plotting.py
+++ b/lir/plotting.py
@@ -468,7 +468,7 @@ def axes(call, savefig=None, show=None):
         plt.close(fig)
 
 
-def plot(call, ax=None, savefig=None, show=None):
+def plot(call, savefig=None, show=None):
     """
     Creates a plot, given a plotting function.
 
@@ -482,20 +482,13 @@ def plot(call, ax=None, savefig=None, show=None):
     ----------
     call : callable
         a callable to generate the plot
-    ax : a pyplot axes object
-        where the plot is generated
     savefig : str
-        if not `None`, write a PNG image to this path (valid only if `ax` is None)
+        if not `None`, write a PNG image to this path
     show : boolean
-        if `True`, show the plot on screen (valid only if `ax` is None)
+        if `True`, show the plot on screen
     """
-    if ax is None:
-        with axes(call, savefig, show) as ax:
-            pass
-    else:
-        assert savefig is None, "both `ax` and `savefig` are provided"
-        assert show is None, "both `ax` and `show` are provided"
-        call(ax=ax)
+    with axes(call, savefig, show) as ax:
+        pass
 
 
 def plot_log_lr_distributions_for_model(lr_system: CalibratedScorer, X, y, kind: str = 'histogram', savefig=None,

--- a/lr.py
+++ b/lr.py
@@ -32,7 +32,7 @@ class Data:
         raise ValueError('not implemented')
 
     def plot_isotonic(self):
-        lir.plotting.plot(lir.plotting.pav(self.lrs, self.y))
+        lir.plotting.plot(lir.plotting.pav(self.lrs, self.y), show=True)
 
     def plot_ece(self):
         lir.ece.plot(self.lrs, self.y, on_screen=True)

--- a/lr.py
+++ b/lr.py
@@ -32,7 +32,7 @@ class Data:
         raise ValueError('not implemented')
 
     def plot_isotonic(self):
-        lir.plotting.plot_pav(self.lrs, self.y)
+        lir.plotting.plot(lir.plotting.pav(self.lrs, self.y))
 
     def plot_ece(self):
         lir.ece.plot(self.lrs, self.y, on_screen=True)


### PR DESCRIPTION
Als we de backward compatibility toch stuk maken, dan hebben we ook de mogelijkheid om het nog wat anders te doen. Dit is een ideetje; graag schieten. Als we dit willen stel ik voor om alle plotting functies op deze manier te doen.

Hoe het nu werkt
-----------------------

Simpel:
```py
plot_pav(lrs, y, savefig='filename.png')
```

Voorstel 0, met context manager
---------------------------

Iets meer typen maar ook meer flexibiliteit:
```py
with plot_pav(lrs, y, savefig='filename.png') as ax:
    ax.xlabel("custom x label")
```

Voorstel 1, deze branch
-------------------------------

In dit voorstel is de plotting zelf losgetrokken van alles er omheen. Dit heeft als voordeel dat je zowel met als zonder context kan werken, keyword arguments voor `figure()` zijn niet meer nodig en je kan eventueel ook met subplots werken als je dat zou willen.

Zonder context, vergelijkbaar met huidige werkwijze maar met extra haakjes:
```py
plot(pav(lrs, y), savefig='filename.png')
```

Of met context, met meer flexibiliteit:
```py
with axes(pav(lrs, y), savefig='filename.png') as ax:
    ax.xlabel("custom x label")
```

Of als je echt alles zelf wil doen voor maximale flexibiliteit:
```py
fig, ax = plt.subplots()
pav(lrs, y)(ax)
ax.savefig('filename.png')
plt.close(fig)
```

Voorstel 2, zie andere branch "take 2"
--------------------------------------------------

Met iets andere calls:
```py
with lir.plotting.show() as ax:
    ax.pav(lrs, y)
    ax.xlabel("custom x label")

with lir.plotting.savefig('filename.png') as ax:
    ax.pav(lrs, y)
    ax.xlabel("custom x label")

with lir.plotting.axes() as ax:
    ax.pav(lrs, y)
    ax.xlabel("custom x label")
    ax.show()

# simple call with full control
fig = plt.figure()
lir.plotting.pav(lrs, y)
plt.savefig('filename.png')
plt.close(fig)

# with sub plots
fig, ax = plt.subplots()
lir.plotting.pav(lrs, y, ax=ax)
ax.savefig('filename.png')
plt.close(fig)
```
