### PR TITLE
Feature/ranking

### DIFF
--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -25,7 +25,7 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
 
 class PercentileRankTransformer(sklearn.base.TransformerMixin):
     """
-    Compute the rankings of a dataset, relative to another dataset.
+    Compute the percentile rankings of a dataset, relative to another dataset.
     Rankings are in range [0, 1]. Handling ties: the maximum of the ranks that
     would have been assigned to all the tied values is assigned to each value.
 

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -33,11 +33,17 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
     'fit' will create a ranking function for each feature, based on X.
     'transform' will apply ranking of Z based on dataset X.
 
+    Fit:
+    Expects:
+        - X is of shape (n, f) with n = number of measurements,
+        f = number of features
+
     Transform:
     Expects:
-        - X is of shape (n,f) with n=number of measurements; f=number of features;
+        - X is of shape (m, f) with m = number of measurements,
+        f = number of features
     Returns:
-        - rankings with shape (n, f)
+        - rankings with shape (m, f)
     """
     def __init__(self):
         self.rank_functions = None

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -26,8 +26,8 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
 class PercentileRankTransformer(sklearn.base.TransformerMixin):
     """
     Compute the rankings of a dataset, relative to another dataset.
-    Rankings are in range [0, 1]. Handling ties: the maximum of the ranks that would
-    have been assigned to all the tied values is assigned to each value.
+    Rankings are in range [0, 1]. Handling ties: the maximum of the ranks that
+    would have been assigned to all the tied values is assigned to each value.
 
     To be able to compute the rankings of dataset Z relative to dataset X,
     'fit' will create a ranking function for each feature, based on X.

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -23,17 +23,15 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
         return np.abs(X[:,:,0] - X[:,:,1])
 
 
-class RankTransformer(sklearn.base.TransformerMixin):
+class PercentileRankTransformer(sklearn.base.TransformerMixin):
     """
     Compute the rankings of a dataset, relative to another dataset.
-    Rankings are in [0, 1]. Handling ties: the maximum of the ranks that would
+    Rankings are in range [0, 1]. Handling ties: the maximum of the ranks that would
     have been assigned to all the tied values is assigned to each value.
 
     To be able to compute the rankings of dataset Z relative to dataset X,
     'fit' will create a ranking function for each feature, based on X.
     'transform' will apply ranking of Z based on dataset X.
-
-
 
     Transform:
     Expects:
@@ -52,9 +50,10 @@ class RankTransformer(sklearn.base.TransformerMixin):
         return self
 
     def transform(self, X):
-        assert self.rank_functions
+        assert self.rank_functions, "transform() called before fit()"
         assert len(X.shape) == 2
-        assert X.shape[1] == len(self.rank_functions)
+        assert X.shape[1] == len(self.rank_functions),\
+            "number of features used for fit() and transform()t should be equal"
         ranks = [self.rank_functions[i](X[:, i]) for i in range(X.shape[1])]
         return np.asarray(ranks).transpose()
 

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -35,7 +35,7 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
 
     Transform:
     Expects:
-        - X is of shape (n,f) with n=number of instances; f=number of features;
+        - X is of shape (n,f) with n=number of measurements; f=number of features;
     Returns:
         - rankings with shape (n, f)
     """

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -25,11 +25,20 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
 
 class RankTransformer(sklearn.base.TransformerMixin):
     """
-    Assign ranks to X, dealing with ties appropriately.
+    Compute the rankings of a dataset, relative to another dataset.
+    Rankings are in [0, 1].
+
+    To be able to compute the rankings of dataset Z relative to dataset X,
+    'fit' will create a ranking function for each feature, based on X.
+    'transform' will apply ranking of Z based on dataset X.
+
+
+
+    Transform:
     Expects:
         - X is of shape (n,f) with n=number of instances; f=number of features;
     Returns:
-        - X has shape (n, f), and y
+        - rankings with shape (n, f)
     """
     def __init__(self):
         self.rank_functions = None
@@ -42,6 +51,7 @@ class RankTransformer(sklearn.base.TransformerMixin):
         return self
 
     def transform(self, X):
+        assert self.rank_functions
         assert len(X.shape) == 2
         assert X.shape[1] == len(self.rank_functions)
         ranks = [self.rank_functions[i](X[:, i]) for i in range(X.shape[1])]

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -59,7 +59,7 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
         assert self.rank_functions, "transform() called before fit()"
         assert len(X.shape) == 2
         assert X.shape[1] == len(self.rank_functions),\
-            "number of features used for fit() and transform()t should be equal"
+            "number of features used for fit() and transform() should be equal"
         ranks = [self.rank_functions[i](X[:, i]) for i in range(X.shape[1])]
         return np.stack(ranks, axis=1)
 

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -26,7 +26,8 @@ class AbsDiffTransformer(sklearn.base.TransformerMixin):
 class RankTransformer(sklearn.base.TransformerMixin):
     """
     Compute the rankings of a dataset, relative to another dataset.
-    Rankings are in [0, 1].
+    Rankings are in [0, 1]. Handling ties: the maximum of the ranks that would
+    have been assigned to all the tied values is assigned to each value.
 
     To be able to compute the rankings of dataset Z relative to dataset X,
     'fit' will create a ranking function for each feature, based on X.
@@ -45,7 +46,7 @@ class RankTransformer(sklearn.base.TransformerMixin):
 
     def fit(self, X, y=None):
         assert len(X.shape) == 2
-        ranks_X = rankdata(X, axis=0)/len(X)
+        ranks_X = rankdata(X, method='max', axis=0)/len(X)
         self.rank_functions = [interp1d(X[:, i], ranks_X[:, i], bounds_error=False,
                                         fill_value=(0, 1)) for i in range(X.shape[1])]
         return self

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -55,7 +55,7 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
         assert X.shape[1] == len(self.rank_functions),\
             "number of features used for fit() and transform()t should be equal"
         ranks = [self.rank_functions[i](X[:, i]) for i in range(X.shape[1])]
-        return np.asarray(ranks).transpose()
+        return np.stack(ranks, axis=1)
 
 
 class InstancePairing(sklearn.base.TransformerMixin):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -4,12 +4,43 @@ import numpy as np
 import unittest
 import warnings
 
+from scipy.stats import rankdata
+
 from context import lir
 
-from lir.transformers import InstancePairing
-
+from lir.transformers import InstancePairing, RankTransformer
 
 warnings.simplefilter("error")
+
+
+class TestRankingTransformer(unittest.TestCase):
+    def test_fit_transform(self):
+        """When X itself is transformed, it should give it's own ranks"""
+        X = np.array([[0.1, 0.4, 0.5],
+                      [0.2, 0.5, 0.55],
+                      [0.15, 0.51, 0.55],
+                      [0.18, 0.45, 0.56]])
+        rank_transformer = RankTransformer()
+        rank_transformer.fit(X)
+        ranks = rank_transformer.transform(X)
+        self.assertSequenceEqual(ranks.tolist(), (rankdata(X, axis=0)/len(X)).tolist(),
+                                 'Ranking X and RankTransform X should give the same results')
+
+    def test_extrapolation(self):
+        """Values smaller than the lowest value should map to 0,
+        values larger than the highest value should map to 1"""
+        X = np.array([[0.1, 0.2, 0.3],
+                      [0.2, 0.2, 0.4],
+                      [0.3, 0.2, 0.5]])
+        Z = np.array([[0.0, 0.1, 0.2],
+                      [1.0, 1.0, 1.0]])
+        rank_transformer = RankTransformer()
+        rank_transformer.fit(X)
+        ranks = rank_transformer.transform(Z)
+        self.assertSequenceEqual(ranks.tolist(),
+                                 np.array([[0, 0, 0], [1, 1, 1]]).tolist(),
+                                 'Elements smaller than lowest value should map'
+                                 ' to 0, larger than highest value to 1')
 
 
 class TestPairing(unittest.TestCase):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -13,7 +13,7 @@ from lir.transformers import InstancePairing, RankTransformer
 warnings.simplefilter("error")
 
 
-class TestRankingTransformer(unittest.TestCase):
+class TestRankTransformer(unittest.TestCase):
     def test_fit_transform(self):
         """When X itself is transformed, it should give it's own ranks"""
         X = np.array([[0.1, 0.4, 0.5],

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -23,7 +23,8 @@ class TestRankTransformer(unittest.TestCase):
         rank_transformer = RankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(X)
-        self.assertSequenceEqual(ranks.tolist(), (rankdata(X, axis=0)/len(X)).tolist(),
+        self.assertSequenceEqual(ranks.tolist(),
+                                 (rankdata(X, method='max', axis=0)/len(X)).tolist(),
                                  'Ranking X and RankTransform X should give the same results')
 
     def test_extrapolation(self):
@@ -42,7 +43,8 @@ class TestRankTransformer(unittest.TestCase):
                                  'map to 0, larger than the highest value to 1')
 
     def test_interpolation(self):
-        """Values inbetween values of X result in interpolated ranking."""
+        """Values inbetween values of X result in interpolated ranking,
+        with linear interpolation."""
         X = np.array([[0, 0, 0],
                       [1, 1, 1]])
         Z = np.array([[0.1, 0.3, 0.5]])
@@ -54,6 +56,18 @@ class TestRankTransformer(unittest.TestCase):
         expected_ranks = 0.5 + np.array([[0.1, 0.3, 0.5]])*0.5
         self.assertSequenceEqual(ranks.tolist(), expected_ranks.tolist(),
                                  'Interpolation failed.')
+
+    def test_ties(self):
+        """Ties are given the maximum value (the maximum of the ranks that would
+        have been assigned to all the tied values is assigned to each value)."""
+        X = np.array([[0.1], [0.1], [0.1], [0.1], [0.3]])
+        Z = np.array([[0.1]])
+        rank_transformer = RankTransformer()
+        rank_transformer.fit(X)
+        ranks = rank_transformer.transform(Z)
+        self.assertEqual(ranks, 0.8, "Ties should be given the maximum value")
+
+
 
 
 class TestPairing(unittest.TestCase):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -69,8 +69,6 @@ class TestPercentileRankTransformer(unittest.TestCase):
         self.assertEqual(ranks, 0.8, "Ties should be given the maximum value")
 
 
-
-
 class TestPairing(unittest.TestCase):
     def test_pairing(self):
         X = np.arange(30).reshape(10, 3)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -8,24 +8,25 @@ from scipy.stats import rankdata
 
 from context import lir
 
-from lir.transformers import InstancePairing, RankTransformer
+from lir.transformers import InstancePairing, PercentileRankTransformer
 
 warnings.simplefilter("error")
 
 
-class TestRankTransformer(unittest.TestCase):
+class TestPercentileRankTransformer(unittest.TestCase):
     def test_fit_transform(self):
         """When X itself is transformed, it should return its own ranks"""
         X = np.array([[0.1, 0.4, 0.5],
                       [0.2, 0.5, 0.55],
                       [0.15, 0.51, 0.55],
                       [0.18, 0.45, 0.56]])
-        rank_transformer = RankTransformer()
+        rank_transformer = PercentileRankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(X)
         self.assertSequenceEqual(ranks.tolist(),
                                  (rankdata(X, method='max', axis=0)/len(X)).tolist(),
-                                 'Ranking X and RankTransform X should give the same results')
+                                 'Ranking X and PercentileRankTransformer.transform(X)'
+                                 ' should give the same results')
 
     def test_extrapolation(self):
         """Values smaller than the lowest value should map to 0,
@@ -35,7 +36,7 @@ class TestRankTransformer(unittest.TestCase):
                       [0.3, 0.2, 0.5]])
         Z = np.array([[0.0, 0.1, 0.2],
                       [1.0, 1.0, 1.0]])
-        rank_transformer = RankTransformer()
+        rank_transformer = PercentileRankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(Z)
         self.assertSequenceEqual(ranks.tolist(), [[0, 0, 0], [1, 1, 1]],
@@ -48,7 +49,7 @@ class TestRankTransformer(unittest.TestCase):
         X = np.array([[0, 0, 0],
                       [1, 1, 1]])
         Z = np.array([[0.1, 0.3, 0.5]])
-        rank_transformer = RankTransformer()
+        rank_transformer = PercentileRankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(Z)
         # Ranks are interpolated between 0.5 (rank of 0) and 1 (rank of 1).
@@ -62,7 +63,7 @@ class TestRankTransformer(unittest.TestCase):
         have been assigned to all the tied values is assigned to each value)."""
         X = np.array([[0.1], [0.1], [0.1], [0.1], [0.3]])
         Z = np.array([[0.1]])
-        rank_transformer = RankTransformer()
+        rank_transformer = PercentileRankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(Z)
         self.assertEqual(ranks, 0.8, "Ties should be given the maximum value")

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -15,7 +15,7 @@ warnings.simplefilter("error")
 
 class TestRankTransformer(unittest.TestCase):
     def test_fit_transform(self):
-        """When X itself is transformed, it should give it's own ranks"""
+        """When X itself is transformed, it should return its own ranks"""
         X = np.array([[0.1, 0.4, 0.5],
                       [0.2, 0.5, 0.55],
                       [0.15, 0.51, 0.55],
@@ -37,10 +37,23 @@ class TestRankTransformer(unittest.TestCase):
         rank_transformer = RankTransformer()
         rank_transformer.fit(X)
         ranks = rank_transformer.transform(Z)
-        self.assertSequenceEqual(ranks.tolist(),
-                                 np.array([[0, 0, 0], [1, 1, 1]]).tolist(),
-                                 'Elements smaller than lowest value should map'
-                                 ' to 0, larger than highest value to 1')
+        self.assertSequenceEqual(ranks.tolist(), [[0, 0, 0], [1, 1, 1]],
+                                 'Elements smaller than the lowest value should'
+                                 'map to 0, larger than the highest value to 1')
+
+    def test_interpolation(self):
+        """Values inbetween values of X result in interpolated ranking."""
+        X = np.array([[0, 0, 0],
+                      [1, 1, 1]])
+        Z = np.array([[0.1, 0.3, 0.5]])
+        rank_transformer = RankTransformer()
+        rank_transformer.fit(X)
+        ranks = rank_transformer.transform(Z)
+        # Ranks are interpolated between 0.5 (rank of 0) and 1 (rank of 1).
+        # We expect a linear interpolation.
+        expected_ranks = 0.5 + np.array([[0.1, 0.3, 0.5]])*0.5
+        self.assertSequenceEqual(ranks.tolist(), expected_ranks.tolist(),
+                                 'Interpolation failed.')
 
 
 class TestPairing(unittest.TestCase):


### PR DESCRIPTION
Update di 9:00: tie handling aangepast, hij pakt nu het maximum (i.e. ranking van [0.1, 0.1, 0.1, 0.3] wordt [0.75, 0.75, 0.75, 1]. Nu klopt de functie verder wel.

---------------------------------

Shoot!

Ranking functie doet nu nog dingen die je niet helemaal verwacht, ga ik morgen mee verder! Het gaat dan om 'ties', die doet hij op zich goed, maar daardoor doet de interpolatie niet altijd wat je wil. Voor nu wel een PR zodat er alvast naar gekeken kan worden.