### PR TITLE
when applying PercentileRankTransformer, convert X to floats

### DIFF
--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -51,6 +51,8 @@ class PercentileRankTransformer(sklearn.base.TransformerMixin):
     def fit(self, X, y=None):
         assert len(X.shape) == 2
         ranks_X = rankdata(X, method='max', axis=0)/len(X)
+        # if a feature is a constant int value, interp1d returns nan -> convert to float
+        X = X.astype(float)
         self.rank_functions = [interp1d(X[:, i], ranks_X[:, i], bounds_error=False,
                                         fill_value=(0, 1)) for i in range(X.shape[1])]
         return self

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -68,6 +68,18 @@ class TestPercentileRankTransformer(unittest.TestCase):
         ranks = rank_transformer.transform(Z)
         self.assertEqual(ranks, 0.8, "Ties should be given the maximum value")
 
+    def test_constant_feature(self):
+        """If a feature is a constant value c, the rank should be 0 for x < c
+        and 1 for x >= c."""
+        X = np.array([[1], [1], [1], [1]])
+        Z = np.array([[0], [1], [2]])
+        rank_transformer = PercentileRankTransformer()
+        rank_transformer.fit(X)
+        ranks = rank_transformer.transform(Z)
+        self.assertEqual(ranks.tolist(), [[0], [1], [1]],
+                         "If a feature is a constant value, "
+                         "interpolation should still work")
+
 
 class TestPairing(unittest.TestCase):
     def test_pairing(self):
@@ -99,6 +111,7 @@ class TestPairing(unittest.TestCase):
 
         self.assertTrue(np.all(X_pairs_1 == X_pairs_2), 'same seed, same X pairs')
         self.assertTrue(np.any(X_pairs_1 != X_pairs_3), 'different seed, different X pairs')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a feature is a constant integer value, interp1d returns nans for that value. Therefore, convert the data to floats before using interp1d.