### PR TITLE
Feature/specify ratio ss ds pairs

### DIFF
--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -91,9 +91,9 @@ class InstancePairing(sklearn.base.TransformerMixin):
             - different_source_limit (int or None or 'balanced'): the maximum number of different source pairs (None = no limit; 'balanced' = number of same source pairs)
             - max_ratio (int or None): maximum ratio between same source and different source pairs.
                 Ratio = ds pairs / ss pairs. The number of ds pairs will not exceed max_ratio * ss pairs.
-                If both ratio, same_source_limit and different_source_limit are specified,
+                If both ratio and same_source_limit/different_source_limit are specified,
                 the number of pairs is chosen such that the max_ratio is preserved and
-                the limits are not exceeded, while taking as many pairs as possible within these constraints.
+                the limit(s) are not exceeded, while taking as many pairs as possible within these constraints.
             - seed (int or None): seed to make pairing reproducible
         """
         self._ss_limit = same_source_limit

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -101,6 +101,12 @@ class InstancePairing(sklearn.base.TransformerMixin):
         self._ratio_limit = ratio_limit
         self.rng = np.random.default_rng(seed=seed)
 
+        if self._ds_limit == 'balanced':
+            warnings.warn('The argument \'balanced\' is deprecated. '
+                          'Use ratio_limit instead.', DeprecationWarning, stacklevel=2)
+            self._ds_limit = None
+            self._ratio_limit = 1
+
     def fit(self, X):
         return self
 
@@ -124,12 +130,6 @@ class InstancePairing(sklearn.base.TransformerMixin):
 
         if self._ss_limit is not None and rows_same.size > self._ss_limit:
             rows_same = self.rng.choice(rows_same, self._ss_limit, replace=False)
-
-        if self._ds_limit == 'balanced':
-            warnings.warn('The argument \'balanced\' is deprecated. '
-                          'Use ratio_limit instead.', DeprecationWarning, stacklevel=2)
-            self._ds_limit = None
-            self._ratio_limit = 1
 
         n_ds_pairs = min(x for x in [rows_same.size * self._ratio_limit if self._ratio_limit else None,
                                      self._ds_limit,

--- a/lir/transformers.py
+++ b/lir/transformers.py
@@ -131,7 +131,7 @@ class InstancePairing(sklearn.base.TransformerMixin):
             else:
                 self._ds_limit = rows_same.size * self._max_ratio
 
-        if self._max_ratio and self._ss_limit and self._ds_limit:
+        if self._max_ratio and self._ds_limit:
             n_ss_pairs = max(self._ss_limit, rows_same.size)
             # only if max_ratio is exceeded, change ds_limit
             if n_ss_pairs * self._max_ratio > self._ds_limit:

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -139,6 +139,21 @@ class TestPairing(unittest.TestCase):
         self.assertLessEqual(np.sum(y_pairs == 0), different_source_limit,
                          'ds pairs limit')
 
+        # test ratio with same_source_limit and different_source_limit
+        max_ratio = 5
+        same_source_limit = 9
+        different_source_limit = 100
+        pairing_ratio_ds_lim = InstancePairing(max_ratio=max_ratio,
+                                               same_source_limit=same_source_limit,
+                                               different_source_limit=different_source_limit)
+        X_pairs, y_pairs = pairing_ratio_ds_lim.transform(self.X, self.y)
+        ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
+        self.assertLessEqual(ratio, max_ratio, 'max_ratio ss and ds pairs exceeded')
+        self.assertLessEqual(np.sum(y_pairs == 1), same_source_limit,
+                             'ss pairs limit')
+        self.assertLessEqual(np.sum(y_pairs == 0), different_source_limit,
+                             'ds pairs limit')
+
     def test_pairing_seed(self):
         pairing_seed_1 = InstancePairing(different_source_limit='balanced', seed=123)
         X_pairs_1, y_pairs_1 = pairing_seed_1.transform(self.X, self.y)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -92,7 +92,7 @@ class TestPairing(unittest.TestCase):
         self.assertEqual(np.sum(y_pairs == 1), 5, 'number of same source pairs')
         self.assertEqual(np.sum(y_pairs == 0), 2*(8+6+4+2), 'number of different source pairs')
 
-        pairing = InstancePairing(different_source_limit='balanced')
+        pairing = InstancePairing(ratio_limit=1)
         X_pairs, y_pairs = pairing.transform(self.X, self.y)
 
         self.assertEqual(np.sum(y_pairs == 1), 5, 'number of same source pairs')
@@ -102,40 +102,40 @@ class TestPairing(unittest.TestCase):
 
     def test_pairing_ratio(self):
         # test ratio
-        max_ratio = 7
-        pairing_ratio = InstancePairing(max_ratio=max_ratio)
+        ratio_limit = 7
+        pairing_ratio = InstancePairing(ratio_limit=ratio_limit)
         X_pairs, y_pairs = pairing_ratio.transform(self.X, self.y)
         ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
-        self.assertEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+        self.assertEqual(ratio, ratio_limit, 'ratio ss ds pairs not correct')
 
-        # if max_ratio exceeds highest possible ratio, all ds pairs are selected
-        max_ratio = 1_000
-        pairing_ratio_max = InstancePairing(max_ratio=max_ratio)
+        # if ratio_limit exceeds highest possible ratio, all ds pairs are selected
+        ratio_limit = 1_000
+        pairing_ratio_max = InstancePairing(ratio_limit=ratio_limit)
         X_pairs, y_pairs = pairing_ratio_max.transform(self.X, self.y)
         ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
-        self.assertLess(ratio, max_ratio,
-                        'realised ratio should be less or equal than max_ratio')
+        self.assertLess(ratio, ratio_limit,
+                        'realised ratio should be less or equal than ratio_limit')
         self.assertEqual(np.sum(y_pairs == 0), 2*(8+6+4+2),
                          'all different source pairs should be selected')
 
         # test ratio with same_source_limit
-        max_ratio = 5
+        ratio_limit = 5
         same_source_limit = 3
-        pairing_ratio_ss_lim = InstancePairing(max_ratio=max_ratio,
+        pairing_ratio_ss_lim = InstancePairing(ratio_limit=ratio_limit,
                                             same_source_limit=same_source_limit)
         X_pairs, y_pairs = pairing_ratio_ss_lim.transform(self.X, self.y)
         ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
-        self.assertEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+        self.assertEqual(ratio, ratio_limit, 'ratio ss ds pairs not correct')
         self.assertEqual(same_source_limit, np.sum(y_pairs == 1), 'ss pairs limit')
 
         # test ratio with different_source_limit
-        max_ratio = 5
+        ratio_limit = 5
         different_source_limit = 20
-        pairing_ratio_ds_lim = InstancePairing(max_ratio=max_ratio,
+        pairing_ratio_ds_lim = InstancePairing(ratio_limit=ratio_limit,
                                                different_source_limit=different_source_limit)
         X_pairs, y_pairs = pairing_ratio_ds_lim.transform(self.X, self.y)
         ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
-        self.assertLessEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+        self.assertLessEqual(ratio, ratio_limit, 'ratio ss ds pairs not correct')
         self.assertLessEqual(np.sum(y_pairs == 0), different_source_limit,
                          'ds pairs limit')
 
@@ -143,25 +143,25 @@ class TestPairing(unittest.TestCase):
         max_ratio = 5
         same_source_limit = 9
         different_source_limit = 30
-        pairing_ratio_ds_lim = InstancePairing(max_ratio=max_ratio,
+        pairing_ratio_ds_lim = InstancePairing(ratio_limit=ratio_limit,
                                                same_source_limit=same_source_limit,
                                                different_source_limit=different_source_limit)
         X_pairs, y_pairs = pairing_ratio_ds_lim.transform(self.X, self.y)
         ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
-        self.assertLessEqual(ratio, max_ratio, 'max_ratio ss and ds pairs exceeded')
+        self.assertLessEqual(ratio, ratio_limit, 'ratio_limit ss and ds pairs exceeded')
         self.assertLessEqual(np.sum(y_pairs == 1), same_source_limit,
                              'ss pairs limit')
         self.assertLessEqual(np.sum(y_pairs == 0), different_source_limit,
                              'ds pairs limit')
 
     def test_pairing_seed(self):
-        pairing_seed_1 = InstancePairing(different_source_limit='balanced', seed=123)
+        pairing_seed_1 = InstancePairing(ratio_limit=1, seed=123)
         X_pairs_1, y_pairs_1 = pairing_seed_1.transform(self.X, self.y)
 
-        pairing_seed_2 = InstancePairing(different_source_limit='balanced', seed=123)
+        pairing_seed_2 = InstancePairing(ratio_limit=1, seed=123)
         X_pairs_2, y_pairs_2 = pairing_seed_2.transform(self.X, self.y)
 
-        pairing_seed_3 = InstancePairing(different_source_limit='balanced', seed=456)
+        pairing_seed_3 = InstancePairing(ratio_limit=1, seed=456)
         X_pairs_3, y_pairs_3 = pairing_seed_3.transform(self.X, self.y)
 
         self.assertTrue(np.all(X_pairs_1 == X_pairs_2), 'same seed, same X pairs')

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -142,7 +142,7 @@ class TestPairing(unittest.TestCase):
         # test ratio with same_source_limit and different_source_limit
         max_ratio = 5
         same_source_limit = 9
-        different_source_limit = 100
+        different_source_limit = 30
         pairing_ratio_ds_lim = InstancePairing(max_ratio=max_ratio,
                                                same_source_limit=same_source_limit,
                                                different_source_limit=different_source_limit)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -82,32 +82,72 @@ class TestPercentileRankTransformer(unittest.TestCase):
 
 
 class TestPairing(unittest.TestCase):
-    def test_pairing(self):
-        X = np.arange(30).reshape(10, 3)
-        y = np.concatenate([np.arange(5), np.arange(5)])
+    X = np.arange(30).reshape(10, 3)
+    y = np.concatenate([np.arange(5), np.arange(5)])
 
+    def test_pairing(self):
         pairing = InstancePairing()
-        X_pairs, y_pairs = pairing.transform(X, y)
+        X_pairs, y_pairs = pairing.transform(self.X, self.y)
 
         self.assertEqual(np.sum(y_pairs == 1), 5, 'number of same source pairs')
         self.assertEqual(np.sum(y_pairs == 0), 2*(8+6+4+2), 'number of different source pairs')
 
         pairing = InstancePairing(different_source_limit='balanced')
-        X_pairs, y_pairs = pairing.transform(X, y)
+        X_pairs, y_pairs = pairing.transform(self.X, self.y)
 
         self.assertEqual(np.sum(y_pairs == 1), 5, 'number of same source pairs')
         self.assertEqual(np.sum(y_pairs == 0), 5, 'number of different source pairs')
 
-        self.assertTrue(np.all(pairing.pairing[:,0] != pairing.pairing[:,1]), 'identity in pairs')
+        self.assertTrue(np.all(pairing.pairing[:, 0] != pairing.pairing[:, 1]), 'identity in pairs')
 
+    def test_pairing_ratio(self):
+        # test ratio
+        max_ratio = 7
+        pairing_ratio = InstancePairing(max_ratio=max_ratio)
+        X_pairs, y_pairs = pairing_ratio.transform(self.X, self.y)
+        ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
+        self.assertEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+
+        # if max_ratio exceeds highest possible ratio, all ds pairs are selected
+        max_ratio = 1_000
+        pairing_ratio_max = InstancePairing(max_ratio=max_ratio)
+        X_pairs, y_pairs = pairing_ratio_max.transform(self.X, self.y)
+        ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
+        self.assertLess(ratio, max_ratio,
+                        'realised ratio should be less or equal than max_ratio')
+        self.assertEqual(np.sum(y_pairs == 0), 2*(8+6+4+2),
+                         'all different source pairs should be selected')
+
+        # test ratio with same_source_limit
+        max_ratio = 5
+        same_source_limit = 3
+        pairing_ratio_ss_lim = InstancePairing(max_ratio=max_ratio,
+                                            same_source_limit=same_source_limit)
+        X_pairs, y_pairs = pairing_ratio_ss_lim.transform(self.X, self.y)
+        ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
+        self.assertEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+        self.assertEqual(same_source_limit, np.sum(y_pairs == 1), 'ss pairs limit')
+
+        # test ratio with different_source_limit
+        max_ratio = 5
+        different_source_limit = 20
+        pairing_ratio_ds_lim = InstancePairing(max_ratio=max_ratio,
+                                               different_source_limit=different_source_limit)
+        X_pairs, y_pairs = pairing_ratio_ds_lim.transform(self.X, self.y)
+        ratio = np.sum(y_pairs == 0) / np.sum(y_pairs == 1)
+        self.assertLessEqual(ratio, max_ratio, 'ratio ss ds pairs not correct')
+        self.assertLessEqual(np.sum(y_pairs == 0), different_source_limit,
+                         'ds pairs limit')
+
+    def test_pairing_seed(self):
         pairing_seed_1 = InstancePairing(different_source_limit='balanced', seed=123)
-        X_pairs_1, y_pairs_1 = pairing_seed_1.transform(X, y)
+        X_pairs_1, y_pairs_1 = pairing_seed_1.transform(self.X, self.y)
 
         pairing_seed_2 = InstancePairing(different_source_limit='balanced', seed=123)
-        X_pairs_2, y_pairs_2 = pairing_seed_2.transform(X, y)
+        X_pairs_2, y_pairs_2 = pairing_seed_2.transform(self.X, self.y)
 
         pairing_seed_3 = InstancePairing(different_source_limit='balanced', seed=456)
-        X_pairs_3, y_pairs_3 = pairing_seed_3.transform(X, y)
+        X_pairs_3, y_pairs_3 = pairing_seed_3.transform(self.X, self.y)
 
         self.assertTrue(np.all(X_pairs_1 == X_pairs_2), 'same seed, same X pairs')
         self.assertTrue(np.any(X_pairs_1 != X_pairs_3), 'different seed, different X pairs')


### PR DESCRIPTION
Option to specify ratio of ds/ss pairs in InstancePairing class. 

Naming: 'max_ratio', since it can become less when there are not enough ds pairs. Name could also be simply 'ratio'.

If max_ratio is specified in combination with same_source_limit and/or different_source_limit, pairs are chosen such that all parameters are respected, while taking as much pairs as possible within these constraints.