### PR TITLE
Exposes the regularization strength parameter in LogitCalibrator

### DIFF
--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -370,7 +370,7 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
     two distributions. Uses logistic regression for interpolation.
     """
 
-    def fit(self, X, y, C=1.0):
+    def fit(self, X, y, **kwargs):
 
         # sanity check
         X = to_log_odds(X)
@@ -383,7 +383,7 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
 
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced', C=C)
+        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
         self._logit.fit(X, y)
         return self
 
@@ -428,10 +428,10 @@ class LogitCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     two distributions. Uses logistic regression for interpolation.
     """
 
-    def fit(self, X, y, C=1.0):
+    def fit(self, X, y, **kwargs):
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced', C=C)
+        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
         self._logit.fit(X, y)
         return self
 

--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -373,7 +373,7 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
     def __init__(self, **kwargs):
         self._logit = LogisticRegression(class_weight='balanced', **kwargs)
 
-    def fit(self, X, y, **kwargs):
+    def fit(self, X, y):
 
         # sanity check
         X = to_log_odds(X)
@@ -432,7 +432,7 @@ class LogitCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     def __init__(self, **kwargs):
         self._logit = LogisticRegression(class_weight='balanced', **kwargs)
 
-    def fit(self, X, y, **kwargs):
+    def fit(self, X, y):
         # train logistic regression
         X = X.reshape(-1, 1)
         self._logit.fit(X, y)

--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -369,6 +369,9 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
     Calculates a likelihood ratio of a score value, provided it is from one of
     two distributions. Uses logistic regression for interpolation.
     """
+    
+    def __init__(self, **kwargs):
+        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
 
     def fit(self, X, y, **kwargs):
 
@@ -383,7 +386,6 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
 
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
         self._logit.fit(X, y)
         return self
 
@@ -427,11 +429,12 @@ class LogitCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     Calculates a likelihood ratio of a score value, provided it is from one of
     two distributions. Uses logistic regression for interpolation.
     """
+    def __init__(self, **kwargs):
+        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
 
     def fit(self, X, y, **kwargs):
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced', **kwargs)
         self._logit.fit(X, y)
         return self
 

--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -370,7 +370,7 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
     two distributions. Uses logistic regression for interpolation.
     """
 
-    def fit(self, X, y):
+    def fit(self, X, y, C=1.0):
 
         # sanity check
         X = to_log_odds(X)
@@ -383,7 +383,7 @@ class LogitCalibrator(BaseEstimator, TransformerMixin):
 
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced')
+        self._logit = LogisticRegression(class_weight='balanced', C=C)
         self._logit.fit(X, y)
         return self
 
@@ -428,10 +428,10 @@ class LogitCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     two distributions. Uses logistic regression for interpolation.
     """
 
-    def fit(self, X, y):
+    def fit(self, X, y, C=1.0):
         # train logistic regression
         X = X.reshape(-1, 1)
-        self._logit = LogisticRegression(class_weight='balanced')
+        self._logit = LogisticRegression(class_weight='balanced', C=C)
         self._logit.fit(X, y)
         return self
 


### PR DESCRIPTION
Change in the .fit methods of the LogitCalibrator and LogitCalibrationInProbabilityDomain classes, so the user can set the strength of the regularization. From the scikit-learn documentation: "C : float, default=1.0. Inverse of regularization strength; must be a positive float. Like in support vector machines, smaller values specify stronger regularization."