### PR TITLE
Tippett plots without extrapolation + type II plots

### DIFF
--- a/lir/_plotting_new.py
+++ b/lir/_plotting_new.py
@@ -219,13 +219,14 @@ def tippett(lrs, y, ax=plt):
     """
     log_lrs = np.log10(lrs)
 
-    xplot = np.linspace(np.min(log_lrs), np.max(log_lrs), 100)
     lr_0, lr_1 = util.Xy_to_Xn(log_lrs, y)
-    perc0 = (sum(i >= xplot for i in lr_0) / len(lr_0)) * 100
-    perc1 = (sum(i >= xplot for i in lr_1) / len(lr_1)) * 100
+    xplot0 = np.linspace(np.min(lr_0), np.max(lr_0), 100)
+    xplot1 = np.linspace(np.min(lr_1), np.max(lr_1), 100)
+    perc0 = (sum(i >= xplot0 for i in lr_0) / len(lr_0)) * 100
+    perc1 = (sum(i >= xplot1 for i in lr_1) / len(lr_1)) * 100
 
-    ax.plot(xplot, perc1, color='b', label='LRs given $\mathregular{H_1}$')
-    ax.plot(xplot, perc0, color='r', label='LRs given $\mathregular{H_2}$')
+    ax.plot(xplot1, perc1, color='b', label='LRs given $\mathregular{H_1}$')
+    ax.plot(xplot0, perc0, color='r', label='LRs given $\mathregular{H_2}$')
     ax.axvline(x=0, color='k', linestyle='--')
     ax.set_xlabel('10log likelihood ratio')
     ax.set_ylabel('Cumulative proportion')

--- a/lir/_plotting_new.py
+++ b/lir/_plotting_new.py
@@ -213,9 +213,20 @@ def lr_histogram(lrs, y, bins=20, weighted=True, ax=plt):
     ax.set_ylabel('count')
 
 
-def tippett(lrs, y, ax=plt):
+def tippett(lrs, y, plot_type=1, ax=plt):
     """
-    plots the 10log lrs
+    plots empirical cumulative distribution functions of same-source and
+        different-sources lrs
+    
+    Parameters
+    ----------
+    lrs : the likelihood ratios
+    y : a numpy array of labels (0 or 1)
+    plot_type : an integer, must be either 1 or 2.
+        In type 1 both curves show proportion of lrs greater than or equal to the
+        x-axis value, while in type 2 the curve for same-source shows the
+        proportion of lrs smaller than or equal to the x-axis value.
+    ax: axes to plot figure to
     """
     log_lrs = np.log10(lrs)
 
@@ -223,8 +234,13 @@ def tippett(lrs, y, ax=plt):
     xplot0 = np.linspace(np.min(lr_0), np.max(lr_0), 100)
     xplot1 = np.linspace(np.min(lr_1), np.max(lr_1), 100)
     perc0 = (sum(i >= xplot0 for i in lr_0) / len(lr_0)) * 100
-    perc1 = (sum(i >= xplot1 for i in lr_1) / len(lr_1)) * 100
-
+    if plot_type==1:
+        perc1 = (sum(i >= xplot1 for i in lr_1) / len(lr_1)) * 100
+    elif plot_type==2:
+        perc1 = (sum(i <= xplot1 for i in lr_1) / len(lr_1)) * 100
+    else:
+        raise ValueError("plot_type must be either 1 or 2.")
+    
     ax.plot(xplot1, perc1, color='b', label='LRs given $\mathregular{H_1}$')
     ax.plot(xplot0, perc0, color='r', label='LRs given $\mathregular{H_2}$')
     ax.axvline(x=0, color='k', linestyle='--')


### PR DESCRIPTION
Modify the  Tippett plot function so it:

1. Only shows values that are present in the validation data, in accordance with Section C.1 of the Consensus on validation of forensic voice comparison (https://doi.org/10.1016/j.scijus.2021.02.002): "Note that the curves do not extend to a y value of zero as they are representations of the empirical cumulative probability distribution, hence the lowest y value corresponds to 1/N where N is the number of same-speaker or different-speaker input pairs (for these illustrative data Ns = 50 and Nd = 200). Note also that the x values of the curves are not extrapolated beyond the values of the actual validation results obtained."

2. Allows Tippett plots of the same type described in the Consensus on validation of forensic voice comparison, Appendix C.1. Previous behavior is maintained with the default option of the new parameter.

Current:
![tippet_old](https://user-images.githubusercontent.com/38961393/204873274-1afa82ab-18e7-4da5-be38-c096a45030de.png)

Proposed (change n. 1):
![tippett_new](https://user-images.githubusercontent.com/38961393/204873332-9635e94b-eb0d-4176-a987-e39beedab4a2.png)

Proposed (change n. 2):
![tippet_type2](https://user-images.githubusercontent.com/38961393/204945299-58848f3d-1d5b-4e56-bb6d-15053062e994.png)