### PR TITLE
CalibratedScorer transforms probabilities to their log odds values before calibration

### DIFF
--- a/lir/calibration.py
+++ b/lir/calibration.py
@@ -289,7 +289,7 @@ class KDECalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
             of the first distribution (kde0) and the second entry for the second
             distribution (if value is None: Silverman's rule of thumb is used)
         """
-        warnings.warn(f"the class {type(self)} will be removed in the future")
+        warnings.warn(f"the class {type(self).__name__} will be removed in the future")
         self.bandwidth: Tuple[Optional[float], Optional[float]] = \
             self._parse_bandwidth(bandwidth)
         self._kde0: Optional[KernelDensity] = None
@@ -423,7 +423,7 @@ class LogitCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     two distributions. Uses logistic regression for interpolation.
     """
     def __init__(self, **kwargs):
-        warnings.warn(f"the class {type(self)} will be removed in the future")
+        warnings.warn(f"the class {type(self).__name__} will be removed in the future")
         self._logit = LogisticRegression(class_weight='balanced', **kwargs)
 
     def fit(self, X, y):
@@ -526,7 +526,7 @@ class GaussianCalibratorInProbabilityDomain(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, n_components_H0=1, n_components_H1=1):
-        warnings.warn(f"the class {type(self)} will be removed in the future")
+        warnings.warn(f"the class {type(self).__name__} will be removed in the future")
         self.n_components_H1 = n_components_H1
         self.n_components_H0 = n_components_H0
 

--- a/lir/lr.py
+++ b/lir/lr.py
@@ -17,8 +17,9 @@ class EstimatorTransformer(TransformerMixin):
     """
     A wrapper for an estimator to make it behave like a transformer.
 
-    In particular, it implements `transform` by calling `predict_proba` on the underlying estimator. Optionally, the
-    probabilities produced by the estimator are transformed by a user specified function.
+    In particular, it implements `transform` by calling `predict_proba` on the underlying estimator, and transforming
+    the probabilities to their corresponding log odds value. Optionally, an alternative transformation function can be
+    specified.
     """
     def __init__(self, estimator, transform_probabilities: Optional[Callable] = to_log_odds):
         self.estimator = estimator

--- a/lir/lr.py
+++ b/lir/lr.py
@@ -72,7 +72,20 @@ class CalibratedScorer:
         """
         self.scorer = _create_transformer(scorer)
         self.calibrator = calibrator
-        self.pipeline = Pipeline([("scorer", self.scorer), ("calibrator", self.calibrator)])
+        self.pipeline = Pipeline([
+            ("scorer", self.scorer),
+            ("reshape", sklearn.preprocessing.FunctionTransformer(self._reshape)),
+            ("calibrator", self.calibrator)
+        ])
+
+    @staticmethod
+    def _reshape(X):
+        if len(X.shape) == 1:
+            return X
+        else:
+            assert len(X) == X.shape[0], f"array has bad dimensions: all dimensions but the first should be 1; found {X.shape}"
+            return X.reshape(-1)
+
 
     def fit(self, X, y):
         self.pipeline.fit(X, y)

--- a/lir/lr.py
+++ b/lir/lr.py
@@ -20,7 +20,7 @@ class EstimatorTransformer(TransformerMixin):
     In particular, it implements `transform` by calling `predict_proba` on the underlying estimator. Optionally, the
     probabilities produced by the estimator are transformed by a user specified function.
     """
-    def __init__(self, estimator, transform_probabilities: Optional[Callable] = lambda x: x):
+    def __init__(self, estimator, transform_probabilities: Optional[Callable] = to_log_odds):
         self.estimator = estimator
         self.transform_probabilities = transform_probabilities
 
@@ -39,7 +39,7 @@ def _create_transformer(scorer):
     if hasattr(scorer, "transform"):
         return scorer
     elif hasattr(scorer, "predict_proba"):
-        return EstimatorTransformer(scorer, transform_probabilities=to_log_odds)
+        return EstimatorTransformer(scorer)
     elif callable(scorer):
         return sklearn.preprocessing.FunctionTransformer(scorer)
     else:

--- a/tests/test_4pl_model.py
+++ b/tests/test_4pl_model.py
@@ -31,7 +31,7 @@ class TestFourParameterLogisticCalibrator(unittest.TestCase):
         four_pl_model.fit(X, y)
 
         logistic = LogisticRegression(penalty='none', class_weight='balanced')
-        logistic.fit(to_log_odds(X[:, None]), y)
+        logistic.fit(X[:, None], y)
         logistic_coef = [logistic.coef_[0][0], logistic.intercept_[0]]
         np.testing.assert_almost_equal(four_pl_model.coef_, logistic_coef, decimal=5)
 

--- a/tests/test_4pl_model.py
+++ b/tests/test_4pl_model.py
@@ -25,6 +25,7 @@ class TestFourParameterLogisticCalibrator(unittest.TestCase):
 
     def test_compare_to_logistic(self):
         X = np.concatenate([self.X_diff, self.X_same])
+        X = to_log_odds(X)
         y = np.concatenate([np.zeros(len(self.X_diff)), np.ones(len(self.X_same))])
         four_pl_model = FourParameterLogisticCalibrator()
         four_pl_model.fit(X, y)
@@ -39,6 +40,7 @@ class TestFourParameterLogisticCalibrator(unittest.TestCase):
         X_diff = np.concatenate([self.X_diff, [0]])
         y = np.concatenate([np.zeros(len(X_diff)), np.ones(len(X_same))])
         X = np.concatenate([X_diff, X_same])
+        X = to_log_odds(X)
 
         four_pl_model = FourParameterLogisticCalibrator()
         four_pl_model.fit(X, y)
@@ -51,6 +53,7 @@ class TestFourParameterLogisticCalibrator(unittest.TestCase):
         X_diff = np.concatenate([self.X_diff, [1, 1 - 10 ** -10]])
         y = np.concatenate([np.zeros(len(X_diff)), np.ones(len(X_same))])
         X = np.concatenate([X_diff, X_same])
+        X = to_log_odds(X)
 
         four_pl_model = FourParameterLogisticCalibrator()
         four_pl_model.fit(X, y)
@@ -63,6 +66,7 @@ class TestFourParameterLogisticCalibrator(unittest.TestCase):
         X_diff = np.concatenate([self.X_diff, [0, 10 ** -10, 1, 1 - 10 ** -10]])
         y = np.concatenate([np.zeros(len(X_diff)), np.ones(len(X_same))])
         X = np.concatenate([X_diff, X_same])
+        X = to_log_odds(X)
 
         four_pl_model = FourParameterLogisticCalibrator()
         four_pl_model.fit(X, y)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -6,9 +6,9 @@ from context import lir
 assert lir  # so import optimizer doesn't remove the line above
 
 from lir.calibration import IsotonicCalibrator
-from lir.calibration import KDECalibrator, KDECalibratorInProbabilityDomain
-from lir.calibration import GaussianCalibrator, GaussianCalibratorInProbabilityDomain
-from lir.calibration import LogitCalibrator, LogitCalibratorInProbabilityDomain
+from lir.calibration import KDECalibrator
+from lir.calibration import GaussianCalibrator
+from lir.calibration import LogitCalibrator
 
 
 from lir.util import Xn_to_Xy, Xy_to_Xn, to_probability, to_log_odds
@@ -85,28 +85,19 @@ class TestKDECalibrator(unittest.TestCase):
     score_class1 = [2.42776744e+05, 5.35255527e+03, 1.50355963e+03, 1.08776892e+03, 2.19083530e+01, 7.13508826e+02,
                     2.23486401e+03, 5.52239060e+03, 1.12077833e+07]
 
-    def test_log_odds_version(self):
+    def test_kde_calibrator(self):
         X, y = Xn_to_Xy(self.score_class0, self.score_class1)
         X = to_probability(X)
+        X = to_log_odds(X)
         desired = [3.59562799e-02, 1.75942116e-11, 2.59633540e-12, 1.36799721e-12, 8.15673411e-03, 2.10030624e-02, 3.70456430e-05, 1.40710861e-18, 1.04459592e-10, 3.14589737e+03, 2.59568527e+02, 1.08519904e+02, 8.56459139e+01, 3.81243702e+00, 6.23873841e+01, 1.43844114e+02, 2.64913149e+02, 1.49097168e+05]
         calibrator = KDECalibrator()
         calibrator.fit(X, y)
         lrs_cal = calibrator.transform(X)
         np.testing.assert_allclose(lrs_cal, desired)
 
-    def test_prob_version(self):
-        X, y = Xn_to_Xy(self.score_class0, self.score_class1)
-        X = to_probability(X)
-        X = to_log_odds(X)
-        # desired is same as directly above
-        desired = [3.59562799e-02, 1.75942116e-11, 2.59633540e-12, 1.36799721e-12, 8.15673411e-03, 2.10030624e-02, 3.70456430e-05, 1.40710861e-18, 1.04459592e-10, 3.14589737e+03, 2.59568527e+02, 1.08519904e+02, 8.56459139e+01, 3.81243702e+00, 6.23873841e+01, 1.43844114e+02, 2.64913149e+02, 1.49097168e+05]
-        calibrator = KDECalibratorInProbabilityDomain()
-        calibrator.fit(X, y)
-        lrs_cal = calibrator.transform(X)
-        np.testing.assert_allclose(lrs_cal, desired)
-
-    def test_log_odds_version_on_extreme_values(self):
+    def test_on_extreme_values(self):
         X = np.array([8.34714300e-002, 1.37045206e-006, 7.09420198e-007, 5.71489187e-007, 2.38531254e-002, 5.24259542e-002, 6.39928887e-004, 8.22553304e-009, 2.57792061e-006, 0.00000000e+000, 9.88131292e-324, 0.00000000e+000, 9.99995881e-001, 9.99813208e-001, 9.99335354e-001, 9.99081531e-001, 9.56347800e-001, 9.98600437e-001, 9.99552746e-001, 9.99818952e-001, 9.99999911e-001, 1.00000000e+000, 1 - np.float_power(10, -16), 1.00000000e+000])
+        X = to_log_odds(X)
         y = np.concatenate((np.zeros(12), np.ones(12)))
         desired = [6.148510640582358, 0.10548096579142373, 0.07571171879632102, 0.06774859414831141, 4.408883097248305, 5.446103603204983, 1.4258427450086562, 0.006102474459494191, 0.14360453961912525, 0.0, 0.0, 0.0, 17.786943105214274, 21.248067409078676, 21.10676921763807, 20.955468109356307, 16.029054988277238, 20.689727349181517, 21.22851434841379, 21.24246276550688, 11.31919250180751, math.inf, 2.846712755553574, math.inf]
         calibrator = KDECalibrator()
@@ -121,28 +112,19 @@ class TestGaussianCalibrator(unittest.TestCase):
     score_class1 = [2.42776744e+05, 5.35255527e+03, 1.50355963e+03, 1.08776892e+03, 2.19083530e+01, 7.13508826e+02,
                     2.23486401e+03, 5.52239060e+03, 1.12077833e+07]
 
-    def test_log_odds_version(self):
+    def test_gaussian_calibrator(self):
         X, y = Xn_to_Xy(self.score_class0, self.score_class1)
         X = to_probability(X)
+        X = to_log_odds(X)
         desired = [3.06533372e-02, 5.92376598e-09, 1.96126088e-09, 1.35801711e-09, 6.71884519e-03, 1.74203890e-02, 6.47951643e-05, 6.33299969e-13, 1.67740156e-08, 2.38575352e+03, 3.62962152e+02, 1.65709775e+02, 1.33992382e+02, 6.90693424e+00, 1.00822553e+02, 2.13452386e+02, 3.69664971e+02, 7.74656845e+03]
         calibrator = GaussianCalibrator()
         calibrator.fit(X, y)
         lrs_cal = calibrator.transform(X)
         np.testing.assert_allclose(lrs_cal, desired)
 
-    def test_prob_version(self):
-        X, y = Xn_to_Xy(self.score_class0, self.score_class1)
-        X = to_probability(X)
-        X = to_log_odds(X)
-        #desired is same as directly above
-        desired = [3.06533372e-02, 5.92376598e-09, 1.96126088e-09, 1.35801711e-09, 6.71884519e-03, 1.74203890e-02, 6.47951643e-05, 6.33299969e-13, 1.67740156e-08, 2.38575352e+03, 3.62962152e+02, 1.65709775e+02, 1.33992382e+02, 6.90693424e+00, 1.00822553e+02, 2.13452386e+02, 3.69664971e+02, 7.74656845e+03]
-        calibrator = GaussianCalibratorInProbabilityDomain()
-        calibrator.fit(X, y)
-        lrs_cal = calibrator.transform(X)
-        np.testing.assert_allclose(lrs_cal, desired)
-
-    def test_log_odds_version_on_extreme_values(self):
+    def test_on_extreme_values(self):
         X = np.array([8.34714300e-002, 1.37045206e-006, 7.09420198e-007, 5.71489187e-007, 2.38531254e-002, 5.24259542e-002, 6.39928887e-004, 8.22553304e-009, 2.57792061e-006, 0.00000000e+000, 9.88131292e-324, 0.00000000e+000, 9.99995881e-001, 9.99813208e-001, 9.99335354e-001, 9.99081531e-001, 9.56347800e-001, 9.98600437e-001, 9.99552746e-001, 9.99818952e-001, 9.99999911e-001, 1.00000000e+000, 1 - np.float_power(10, -16), 1.00000000e+000])
+        X = to_log_odds(X)
         y = np.concatenate((np.zeros(12), np.ones(12)))
         desired = [10.32769696, 0.74618471, 0.60926507, 0.56937812, 8.17855707, 9.47736296, 3.84324551, 0.13454357, 0.90195449, 0., 0., 0., 33.61358218, 31.95734672, 30.21933616, 29.69865022, 21.78925988, 28.97856863, 30.81599664, 31.99346455, 29.61269015, np.inf, 0.7317451, np.inf]
         calibrator = GaussianCalibrator()
@@ -157,28 +139,19 @@ class TestLogitCalibrator(unittest.TestCase):
     score_class1 = [2.42776744e+05, 5.35255527e+03, 1.50355963e+03, 1.08776892e+03, 2.19083530e+01, 7.13508826e+02,
                     2.23486401e+03, 5.52239060e+03, 1.12077833e+07]
 
-    def test_log_odds_version(self):
+    def test_prob_version(self):
         X, y = Xn_to_Xy(self.score_class0, self.score_class1)
         X = to_probability(X)
+        X = to_log_odds(X)
         desired = [1.79732352e-01, 4.16251897e-04, 2.90464504e-04, 2.58097514e-04, 8.75801433e-02, 1.36880766e-01, 1.19709662e-02, 2.54277585e-05, 5.87902757e-04, 5.83462439e+02, 7.25669320e+01, 3.62580218e+01, 3.03795948e+01, 3.59619089e+00, 2.41271821e+01, 4.50261471e+01, 7.38162334e+01, 4.73670703e+03]
         calibrator = LogitCalibrator()
         calibrator.fit(X, y)
         lrs_cal = calibrator.transform(X)
         np.testing.assert_allclose(lrs_cal, desired)
 
-    def test_prob_version(self):
-        X, y = Xn_to_Xy(self.score_class0, self.score_class1)
-        X = to_probability(X)
-        X = to_log_odds(X)
-        # desired is same as directly above
-        desired = [1.79732352e-01, 4.16251897e-04, 2.90464504e-04, 2.58097514e-04, 8.75801433e-02, 1.36880766e-01, 1.19709662e-02, 2.54277585e-05, 5.87902757e-04, 5.83462439e+02, 7.25669320e+01, 3.62580218e+01, 3.03795948e+01, 3.59619089e+00, 2.41271821e+01, 4.50261471e+01, 7.38162334e+01, 4.73670703e+03]
-        calibrator = LogitCalibratorInProbabilityDomain()
-        calibrator.fit(X, y)
-        lrs_cal = calibrator.transform(X)
-        np.testing.assert_allclose(lrs_cal, desired)
-
-    def test_log_odds_version_on_extreme_values(self):
+    def test_on_extreme_values(self):
         X = np.array([8.34714300e-002, 1.37045206e-006, 7.09420198e-007, 5.71489187e-007, 2.38531254e-002, 5.24259542e-002, 6.39928887e-004, 8.22553304e-009, 2.57792061e-006, 0.00000000e+000, 9.88131292e-324, 0.00000000e+000, 9.99995881e-001, 9.99813208e-001, 9.99335354e-001, 9.99081531e-001, 9.56347800e-001, 9.98600437e-001, 9.99552746e-001, 9.99818952e-001, 9.99999911e-001, 1.00000000e+000, 1 - np.float_power(10, -16), 1.00000000e+000])
+        X = to_log_odds(X)
         y = np.concatenate((np.zeros(12), np.ones(12)))
         desired = [1.79732355e-001, 4.16251962e-004, 2.90464552e-004, 2.58097558e-004, 8.75801462e-002, 1.36880769e-001, 1.19709672e-002, 2.54277642e-005, 5.87902845e-004, 0.00000000e+000, 2.07535143e-177, 0.00000000e+000, 5.83462338e+002, 7.25669230e+001, 3.62580179e+001, 3.03795916e+001, 3.59619069e+000, 2.41271798e+001, 4.50261420e+001, 7.38162243e+001, 4.73670598e+003, np.inf, 3.48058077e+008, np.inf]
         calibrator = LogitCalibrator()

--- a/tests/test_lr.py
+++ b/tests/test_lr.py
@@ -5,12 +5,13 @@ import warnings
 import sklearn
 
 from context import lir
+
 assert lir  # so import optimizer doesn't remove the line above
 
 from sklearn.linear_model import LogisticRegression
 
 from lir.calibration import FractionCalibrator, ScalingCalibrator, KDECalibrator, FourParameterLogisticCalibrator, \
-    LogitCalibrator, LogitCalibratorInProbabilityDomain
+    LogitCalibrator
 from lir import metrics
 from lir.lr import scorebased_cllr, CalibratedScorer, CalibratedScorerCV
 from lir.util import Xn_to_Xy
@@ -105,15 +106,15 @@ class TestLR(unittest.TestCase):
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(LogisticRegression(), LogitCalibrator())
+        calibrated_scorer = CalibratedScorer(LogisticRegression(), FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(sklearn.preprocessing.StandardScaler(), LogitCalibratorInProbabilityDomain())
+        calibrated_scorer = CalibratedScorer(sklearn.preprocessing.StandardScaler(), FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(lambda x: x, LogitCalibratorInProbabilityDomain())
+        calibrated_scorer = CalibratedScorer(lambda x: x, FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
@@ -125,15 +126,15 @@ class TestLR(unittest.TestCase):
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(LogisticRegression(), LogitCalibrator())
+        calibrated_scorer = CalibratedScorer(LogisticRegression(), FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(sklearn.preprocessing.StandardScaler(), LogitCalibratorInProbabilityDomain())
+        calibrated_scorer = CalibratedScorer(sklearn.preprocessing.StandardScaler(), FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorer(lambda x: x, LogitCalibratorInProbabilityDomain())
+        calibrated_scorer = CalibratedScorer(lambda x: x, FourParameterLogisticCalibrator())
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
@@ -152,11 +153,11 @@ class TestLR(unittest.TestCase):
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorerCV(sklearn.preprocessing.StandardScaler(), LogitCalibratorInProbabilityDomain(), n_splits=5)
+        calibrated_scorer = CalibratedScorerCV(sklearn.preprocessing.StandardScaler(), LogitCalibrator(), n_splits=5)
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorerCV(lambda x: x, LogitCalibratorInProbabilityDomain(), n_splits=5)
+        calibrated_scorer = CalibratedScorerCV(lambda x: x, LogitCalibrator(), n_splits=5)
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(1, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
@@ -172,11 +173,11 @@ class TestLR(unittest.TestCase):
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorerCV(sklearn.preprocessing.StandardScaler(), LogitCalibratorInProbabilityDomain(), n_splits=5)
+        calibrated_scorer = CalibratedScorerCV(sklearn.preprocessing.StandardScaler(), LogitCalibrator(), n_splits=5)
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 
-        calibrated_scorer = CalibratedScorerCV(lambda x: x, LogitCalibratorInProbabilityDomain(), n_splits=5)
+        calibrated_scorer = CalibratedScorerCV(lambda x: x, LogitCalibrator(), n_splits=5)
         calibrated_scorer.fit(X, y)
         self.assertAlmostEqual(0, metrics.cllr(calibrated_scorer.predict_lr(X), y), places=2)
 


### PR DESCRIPTION
This seems to be a reasonable default for all calibrators (but it may break things for existing users).

*Note:* this is a draft PR because unit tests have to be fixed