### PR TITLE
Set release stage to use auth token specific to the lir package

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -75,8 +75,8 @@ jobs:
     - name: Publish to PyPI
       if: github.ref == 'refs/heads/master'
       env:
-        TWINE_USERNAME: fbda
-        TWINE_PASSWORD: ${{ secrets.PYPI_FBDA_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         twine upload dist/*
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Account password was updated and the organization wide secret removed, projects will get their own tokens.